### PR TITLE
fix(linter): log transpilation errors of workspace rules

### DIFF
--- a/packages/eslint-plugin/src/resolve-workspace-rules.ts
+++ b/packages/eslint-plugin/src/resolve-workspace-rules.ts
@@ -31,6 +31,7 @@ export const workspaceRules = ((): ESLintRules => {
     }
     return namespacedRules;
   } catch (err) {
+    console.error(err);
     return {};
   } finally {
     if (registrationCleanup) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
Currently, transpilation-related errors of workspace rules are swallowed, so if you run `npx eslint` you will get not-so-informative:
```
C:\project\src\main.js
  1:1  error  Definition for rule '@nx/workspace-example was not found  @nx/workspace-example

✖ 1 problem (1 error, 0 warnings)
```

## Expected Behavior
I'd expected to see the error and a stacktrace like this:
```
TypeError: Cannot read properties of undefined (reading '_events')
    at _addListener (node:events:549:19)
    at addListener (node:events:606:10)
    at Object.<anonymous> (C:\project\tools\eslint-rules\rules\examplets:18:3)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._compile (C:\project\node_modules\pirates\lib\index.js:117:24)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Object.newLoader [as .ts] (C:\project\node_modules\pirates\lib\index.js:121:7)      
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Function.Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)

C:\project\src\main.js
  1:1  error  Definition for rule '@nx/workspace-example was not found  @nx/workspace-example

✖ 1 problem (1 error, 0 warnings)
```
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


